### PR TITLE
Change selector from aria-label to data-article-date

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -9,7 +9,7 @@
   const debug = new URLSearchParams(window.location.search).get("jp-learn-microsoft-com-update-checker-debug");
 
   // Get Japanese date element
-  const japaneseDateElement = document.querySelector('time[aria-label="記事のレビュー日"]');
+  const japaneseDateElement = document.querySelector('time[data-article-date]');
   if (!japaneseDateElement) return;
 
   // Parse Japanese date
@@ -28,7 +28,7 @@
     const parser = new DOMParser();
     const doc = parser.parseFromString(data, "text/html");
 
-    const englishDateStr = doc.querySelector('time[aria-label="Article review date"]')?.getAttribute("datetime");
+    const englishDateStr = doc.querySelector('time[data-article-date]')?.getAttribute("datetime");
     if (!englishDateStr) return;
     const englishDate = new Date(englishDateStr);
 


### PR DESCRIPTION
## Why

In the case of text, since the content is likely to be changed on a language-by-language basis, labels should be used.

## What

change from 'aria-label' to 'data-article-date'