### PR TITLE
Bump up to 1.3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "JP Learn Microsoft.com Update Checker",
-  "version": "1.2",
+  "version": "1.3",
   "description": "Checks the English version update date on Microsoft Learn pages and compares it with the Japanese version to notify users.",
   "permissions": [],
   "icons": {


### PR DESCRIPTION
This pull request includes a small change to the `manifest.json` file. The change updates the version number from `1.2` to `1.3`.

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L4-R4): Updated the version number from `1.2` to `1.3`.