### PR TITLE
languageLabels is a dictionary that maps message from language codes to the corresponding language

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,3 +1,9 @@
+// languageLabels is a dictionary that maps message from language codes to the corresponding language
+const languageLabels = {
+  'ja-jp': '英語版の更新日',
+  // Add more language labels as needed
+};
+
 (async () => {
   // Get current URL
   const currentUrl = window.location.href;
@@ -70,7 +76,11 @@
         updateInfo.className = textColorClass; // Apply appropriate text color based on theme
       }
 
-      updateInfo.innerHTML = informationIcon + `英語版の更新日: <a href="${englishUrl}" target="_blank" class="${textColorClass}">${englishDate.toLocaleDateString(currentLang)}</a>`;
+      // Set update info text based on language
+      const languageLabel = languageLabels[currentLang] || 'last updated on';
+
+      // Display update info
+      updateInfo.innerHTML = informationIcon + `${languageLabel}: <a href="${englishUrl}" target="_blank" class="${textColorClass}">${englishDate.toLocaleDateString(currentLang)}</a>`;
     }
     updateClass();
     const observer = new MutationObserver(updateClass);

--- a/tests/e2e/content.e2e.test.js
+++ b/tests/e2e/content.e2e.test.js
@@ -45,6 +45,22 @@ describe('JP Learn Microsoft.com Update Checker E2E Test', () => {
     expect(englishDateText).toMatch(/英語版の更新日:/);
   });
 
+  test('should display English update date on zh-cn Microsoft Learn page', async () => {
+    await page.goto('https://learn.microsoft.com/zh-cn/azure/virtual-machines/overview');
+    // Wait for the time element with the 'data-article-date' attribute to be added
+    await page.waitForSelector('time[data-article-date]');
+
+    const englishDateText = await page.evaluate(() => {
+      return new Promise(resolve => setTimeout(resolve, 1000)) // Add a delay to allow time for the element to be added
+        .then(() => {
+          const paragraphs = Array.from(document.querySelectorAll('p'));
+          const targetParagraph = paragraphs.find(p => p.textContent.includes('last updated on:'));
+          return targetParagraph ? targetParagraph.innerText : null;
+        });
+    });
+    expect(englishDateText).toMatch(/last updated on:/);
+  });
+
   test('should display light theme when button[data-theme-to]=light and button[aria-pressed]=true', async () => {
     await page.goto('https://learn.microsoft.com/ja-jp/azure/virtual-machines/overview');
 

--- a/tests/e2e/content.e2e.test.js
+++ b/tests/e2e/content.e2e.test.js
@@ -121,12 +121,6 @@ describe('JP Learn Microsoft.com Update Checker E2E Test', () => {
     expect(hasTextColorClass).toBe(true);
   });
 
-  test('should not run script on non-ja-jp pages', async () => {
-    await page.goto('https://learn.microsoft.com/en-us/azure/virtual-machines/overview');
-    const japaneseDateElement = await page.$('time[aria-label="記事のレビュー日"]');
-    expect(japaneseDateElement).toBeNull();
-  });
-
   test('should not run script on en-us pages on light theme', async () => {
     await page.goto('https://learn.microsoft.com/en-us/azure/virtual-machines/overview');
 


### PR DESCRIPTION
This pull request includes changes to the `src/content.js` file to enhance language support by introducing a dictionary for language labels and updating the way update information is displayed based on the current language.

Enhancements to language support:

* [`src/content.js`](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fR1-R6): Added a `languageLabels` dictionary to map language codes to their corresponding language labels.
* [`src/content.js`](diffhunk://#diff-1f93cd4783614fe92bbb9d7fba4cd2b31ba1a47c0c2e9b00be36bd3246e5af7fL73-R83): Modified the update information display logic to use the `languageLabels` dictionary, ensuring the text is shown in the appropriate language.