### PR TITLE
Run in all languages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://learn.microsoft.com/ja-jp/*"],
+      "matches": ["https://learn.microsoft.com/*"],
       "js": ["src/content.js"],
       "css": ["src/styles.css"]
     }


### PR DESCRIPTION
This pull request includes a minor change to the `manifest.json` file. The change broadens the scope of the content script to include all locales of the Microsoft Learn website, rather than just the Japanese locale.

* [`manifest.json`](diffhunk://#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743L14-R14): Updated the `matches` pattern to apply the content script to all locales of the Microsoft Learn website.